### PR TITLE
Bump versions of activemodel and activerecord to pickup security patches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord'
+gem "activerecord", "~> 4.2"
 gem 'redlock'
 
 platform :ruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,26 +6,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.4)
-      activesupport (= 4.2.4)
+    activemodel (4.2.10)
+      activesupport (= 4.2.10)
       builder (~> 3.1)
-    activerecord (4.2.4)
-      activemodel (= 4.2.4)
-      activesupport (= 4.2.4)
+    activerecord (4.2.10)
+      activemodel (= 4.2.10)
+      activesupport (= 4.2.10)
       arel (~> 6.0)
-    activesupport (4.2.4)
+    activesupport (4.2.10)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.3)
-    builder (3.2.2)
+    arel (6.0.4)
+    builder (3.2.3)
+    concurrent-ruby (1.1.3)
     diff-lcs (1.2.5)
-    i18n (0.7.0)
-    json (1.8.6)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
-    minitest (5.8.1)
+    minitest (5.11.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     pg (0.18.3)
@@ -45,15 +45,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
+  activerecord (~> 4.2)
   mocha (~> 1.1)
   pg
   redlock
@@ -61,4 +61,4 @@ DEPENDENCIES
   travis-lock!
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
activemodel:
https://nvd.nist.gov/vuln/detail/CVE-2016-0753

activerecord:
https://nvd.nist.gov/vuln/detail/CVE-2016-6317